### PR TITLE
Divison by Zero bug fixed

### DIFF
--- a/taggit_templatetags/templatetags/taggit_extras.py
+++ b/taggit_templatetags/templatetags/taggit_extras.py
@@ -42,7 +42,13 @@ def get_queryset(forvar=None):
 
 def get_weight_fun(t_min, t_max, f_min, f_max):
     def weight_fun(f_i, t_min=t_min, t_max=t_max, f_min=f_min, f_max=f_max):
-        mult_fac = float(t_max-t_min)/float(f_max-f_min)
+        # Prevent a division by zero here, found to occur under some
+        # pathological but nevertheless actually occurring circumstances.
+        if f_max == f_min:
+            mult_fac = 1.0
+        else:
+            mult_fac = float(t_max-t_min)/float(f_max-f_min)
+            
         return t_max - (f_max-f_i)*mult_fac
     return weight_fun
 


### PR DESCRIPTION
Hey there,

Found and fixed a small but significant bug. I think it happened because in my debug situation the maximal and minimal occurrence of _any_ tag was equal to one, and hence the normalization failed.

For now, I have chosen to pick a normalization factor of 1 if this situation happends. I did not take the time to dive well within the code so it might be a bad choice - I'll leave that for you to decide.

In any case you might want to have regression test for this little bugger. I'll try and see what I can do in the next few days but I'm fairly time constrained.

Kind regards,
Mathijs
