### PR TITLE
Fix on MANIFEST.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Files to ignore by default in Git #
+#####################################
+*.pyc
+*.db
+*.jar
+*.gz
+*.tar
+*.zip
+*.db
+*.dll
+
+# DB and other log files #
+##########################
+*.log
+*.db
+*.sqlite
+*.sql
+
+# Specific Files to ignore #
+############################
+localsettings.py
+Thumbs.db
+Icon?
+.DS_Store?
+ehthumbs.db
+.idea

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
 include *.txt
-recursive-include taggit_templatetags/templates/taggit_templatetags/ *.html
+recursive-include taggit_templatetags *.html


### PR DESCRIPTION
As pointed out in issue #10 the setting for MANIFEST.in/recursive-include was causing an error when installing on windows.  I implemented the fix suggested by that user.
