### PR TITLE
Added support for specific QuerySets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.py[co]
+*.*~
+dist
+build
+*egg-info

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ In your templates, you need to load ``taggit_extras``::
 Taglists
 --------
 
-After loading ``taggit_extras`` you can create a list of tags for the whole project (in the sense of djangoproject), for an app (in the sense of djangoapp), for a model-class (to get a list for an instance of a model, just use its tag-field).
+After loading ``taggit_extras`` you can create a list of tags for the whole project (in the sense of djangoproject), for an app (in the sense of djangoapp), for a model-class (to get a list for an instance of a model, just use its tag-field), or for a specific queryset.
 
 For the tags of a project, just do::
 
@@ -47,6 +47,10 @@ For the tags of an app, just do::
 For the tags of an model, just do::
 
     {% get_taglist as tags for 'yourapp.yourmodel' %}
+
+For the tags of a specific queryset, just do::
+
+    {% get_list as tags for queryset %}
     
 No matter what you do, you have a list of tags in the ``tags`` template variable. You can now iterate over it::
 
@@ -80,6 +84,10 @@ or::
 or::
 
     {% get_tagcloud as tags for 'yourapp.yourmodel' %}
+
+or::
+
+    {% get_tagcloud as tags for queryset %}
     
 respectivly. The resulting list of tags is ordered by their ``name`` attribute. Besides the ``num_items`` attribute, there's a ``weight`` attribute. Its maximum and minimum may be specified as the settings_ section reads.
 

--- a/taggit_templatetags/templatetags/taggit_extras.py
+++ b/taggit_templatetags/templatetags/taggit_extras.py
@@ -50,7 +50,9 @@ def get_queryset(forvar=None):
             queryset = queryset.filter(content_type__model=model.lower())
             
         # get tags
-        tag_ids = queryset.values_list('tag_id', flat=True)
+        # this is interesting: if we don't make tag_ids as a list, even if
+        # empty it will get all the tags from Tag.objects.filter(id__in=tag_ids)
+        tag_ids = list(queryset.values_list('tag_id', flat=True))
         queryset = Tag.objects.filter(id__in=tag_ids)
         occurrences = _count(tag_ids)
     else:
@@ -62,7 +64,7 @@ def get_queryset(forvar=None):
                         .filter(object_id__in=[x.pk for x in forvar])
 
         # get tags
-        tag_ids = queryset.values_list('tag_id', flat=True)
+        tag_ids = list(queryset.values_list('tag_id', flat=True))
         queryset = Tag.objects.filter(id__in=tag_ids)
         occurrences = _count(tag_ids)
 

--- a/taggit_templatetags/templatetags/taggit_extras.py
+++ b/taggit_templatetags/templatetags/taggit_extras.py
@@ -32,7 +32,7 @@ def get_queryset(forvar=None):
         # get all tags
         queryset = Tag.objects.all()
         occurrences = {}
-    elif isinstance(forvar, str):
+    elif isinstance(forvar, basestring):
         # extract app label and model name
         beginning, applabel, model = None, None, None
         try:

--- a/taggit_templatetags/templatetags/taggit_extras.py
+++ b/taggit_templatetags/templatetags/taggit_extras.py
@@ -97,15 +97,15 @@ def get_taglist(context, asvar, forvar=None):
 def get_tagcloud(context, asvar, forvar=None):
     queryset, occurrences = get_queryset(forvar)
 
-    annot_num_times = queryset.values_list('num_times', flat=True)
-    num_times = [occurrences.get(tag.pk, annot_num_times[i]) for i, tag in enumerate(queryset)]
+    num_times = occurrences.values() if len(occurrences) \
+        else queryset.values_list('num_times', flat=True)
     if(len(num_times) == 0):
         context[asvar] = queryset
         return ''
     weight_fun = get_weight_fun(T_MIN, T_MAX, min(num_times), max(num_times))
     queryset = queryset.order_by('name')
     for i, tag in enumerate(queryset):
-        tag.weight = weight_fun(num_times[i])
+        tag.weight = weight_fun(occurrences.get(tag.pk, tag.num_times))
     context[asvar] = queryset
     return ''
     


### PR DESCRIPTION
Now it is possible to extract tags also from a queryset of generic objects (i.e.: subsets of a specific model)
