### PR TITLE
Fixing MANIFEST to let install *.html files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
 include *.txt
-recursive-include taggit_templatetags/templates/taggit_templatetags/ *.html
+recursive-include taggit_templatetags/templates/taggit_templatetags *.html


### PR DESCRIPTION
The path used to install the templates on MANIFEST.in doesn't work using pip with version 1.4.1 and distribute with version 0.7.3.
Some older versions from pip and distribute somehow find and install the templates but the newers versions don't.
So it was necessary to change the path by deleting the last "/" from it to make it work.
